### PR TITLE
Mobile layout: Ensure heading text doesn't touch side of viewport

### DIFF
--- a/style.sass
+++ b/style.sass
@@ -100,8 +100,9 @@ body
       position: absolute
 
   h1
-    margin: 0
+    margin: 0 auto
     font-size: 3.5rem
+    max-width: calc(100vw - 1rem)
 
   nav
     display: flex
@@ -122,7 +123,9 @@ body
       padding: 0 0.9em
 
     h2
+      margin: 0 auto
       font-size: 1.4em
+      max-width: calc(100vw - 1rem)
 
   .project
     display: flex

--- a/style.sass
+++ b/style.sass
@@ -123,7 +123,8 @@ body
       padding: 0 0.9em
 
     h2
-      margin: 0 auto
+      margin-left: auto
+      margin-right: auto
       font-size: 1.4em
       max-width: calc(100vw - 1rem)
 


### PR DESCRIPTION
Use margin: auto to center, max-width to constrain if the text fills up the viewport. This keeps elements like the project icons right up against the edge, and keeps the text as wide as those elements, unless doing so would place text too close to the edge of the viewport (i.e., on mobile).